### PR TITLE
Replace freq/dlnf with f_start/f_end in tone tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ The `dlnf` parameter is per-hop and internally scaled by 2 for the full window. 
 
 ### `src/fuge/spectral/embedding.py` — `ToneTokenEmbedding(nn.Module)`
 
-Transforms raw spectral peak tokens (freq, dlnf, amp, phase_start, phase_end) into model-ready embedded features with z-score normalization. Previously named `TokenEmbedding`; a backwards-compat alias exists in `fuge.__init__`.
+Transforms raw tone tokens (f_start, f_end, amp, phase_start, phase_end) into model-ready embedded features with z-score normalization.
 
 ### `src/fuge/nn.py` — `TransformerEmbedding(nn.Module)`
 

--- a/README.md
+++ b/README.md
@@ -44,17 +44,17 @@ Chains de-chirped STFT, peak finding, and phase extraction into a single batched
 (B, N) signal -> (B, W, K, 5) raw tokens
 ```
 
-Each token represents one spectral peak in one time window, with 5 raw features:
+Each token represents one tone in one time window, with 5 raw features:
 
 | Feature | Description |
 |---|---|
-| `freq` | Fractional frequency bin index (parabolic-interpolated) |
-| `dlnf` | Relative chirp rate (d ln f / dt, interpolated) |
+| `f_start` | Frequency bin index at half-window start (t = -0.5) |
+| `f_end` | Frequency bin index at half-window end (t = +0.5) |
 | `amp` | Peak amplitude (or SNR when whitening is active) |
 | `phase_start` | Phase at half-window start (t = -0.5) |
 | `phase_end` | Phase at half-window end (t = +0.5) |
 
-Phase boundaries overlap between adjacent windows: `phase_end[w] = phase_start[w+1]` for clean signals.
+All boundary values tile across adjacent windows: `f_end[w] = f_start[w+1]` and `phase_end[w] = phase_start[w+1]` for clean signals.
 
 **Constructor parameters:**
 - `k` — Window size / FFT size (default 1024)
@@ -150,4 +150,4 @@ fuge/
 
 **Modular embedding design:** Each embedding type lives in its own subpackage (e.g. `fuge.spectral`). Generic neural network components live in `fuge.nn` and accept pre-embedded tensors of any dimension, making them reusable across embedding types.
 
-**Token design:** Phases are defined at half-window boundaries so they tile the signal without gaps. The `phase_center` can be recovered as `(phase_start + phase_end) / 2`. With 50% Hann window overlap, `phase_end[w]` coincides exactly with `phase_start[w+1]` for noiseless signals, enabling coherent phase tracking across windows.
+**Token design:** Both frequency and phase are defined at half-window boundaries so they tile the signal without gaps. With 50% Hann window overlap, `f_end[w] ≈ f_start[w+1]` and `phase_end[w] ≈ phase_start[w+1]` for noiseless signals, enabling coherent tracking across windows. Center values can be recovered as `(start + end) / 2`.

--- a/src/fuge/spectral/core.py
+++ b/src/fuge/spectral/core.py
@@ -377,7 +377,10 @@ class ToneTokenizer(nn.Module):
     Output
     ------
     forward(x) returns raw tokens of shape (B, N_WINDOWS, n_peaks, 5)
-    with 5 values per peak: [freq, dlnf, amp, phase_start, phase_end].
+    with 5 values per peak: [f_start, f_end, amp, phase_start, phase_end].
+    f_start and f_end are fractional frequency bin indices at the half-window
+    boundaries (t = -0.5 and t = +0.5 in Hann window coords).  For adjacent
+    windows, f_end[w] ≈ f_start[w+1] for clean signals.
     When whitening is active, amp reflects SNR (amplitude / noise_std).
     """
 
@@ -463,8 +466,9 @@ class ToneTokenizer(nn.Module):
         Returns
         -------
         tokens : Tensor, shape (B, W, K, 5) or (W, K, 5)
-            Raw values per peak: [freq, dlnf, amp, phase_start, phase_end].
-            W = number of time windows, K = n_peaks.
+            Raw values per peak: [f_start, f_end, amp, phase_start, phase_end].
+            f_start/f_end are fractional frequency bin indices at half-window
+            boundaries.  W = number of time windows, K = n_peaks.
             When whitening is active, amp is SNR (amplitude / noise_std).
         """
         squeeze = x.dim() == 1
@@ -481,7 +485,12 @@ class ToneTokenizer(nn.Module):
         ps, pe = self.decomposer.peak_phases(
             X, peaks, freq, dlnf, self.dlnf_grid)
 
-        tokens = torch.stack([freq, dlnf, amp, ps, pe], dim=-1)  # (B, W, K, 5)
+        # Frequency at half-window boundaries (dlnf is per hop,
+        # boundaries are ±0.5 hops from center)
+        f_start = freq * torch.exp(-dlnf / 2)
+        f_end = freq * torch.exp(dlnf / 2)
+
+        tokens = torch.stack([f_start, f_end, amp, ps, pe], dim=-1)  # (B, W, K, 5)
 
         if squeeze:
             tokens = tokens.squeeze(0)

--- a/src/fuge/spectral/embedding.py
+++ b/src/fuge/spectral/embedding.py
@@ -1,6 +1,6 @@
-"""Spectral token embedding: raw (B, W, K, 5) tokens -> (B, W*K, n_embed).
+"""Tone token embedding: raw (B, W, K, 5) tokens -> (B, W*K, n_embed).
 
-Transforms raw spectral peak features (freq, dlnf, amp, phase_start,
+Transforms raw tone features (f_start, f_end, amp, phase_start,
 phase_end) into model-ready embedded features with z-score normalization.
 """
 
@@ -50,18 +50,18 @@ class ToneTokenEmbedding(nn.Module):
 
         (B, W, K, 5) -> (B, W, K, n_embed)
         """
-        freq = raw_tokens[..., 0]
-        dlnf = raw_tokens[..., 1]
+        f_start = raw_tokens[..., 0]
+        f_end = raw_tokens[..., 1]
         amp = torch.log1p(raw_tokens[..., 2])
         ps = raw_tokens[..., 3]
         pe = raw_tokens[..., 4]
 
         if self.phase_mode == "center":
             phi = (ps + pe) / 2
-            out = torch.stack([freq, dlnf, amp,
+            out = torch.stack([f_start, f_end, amp,
                                torch.cos(phi), torch.sin(phi)], dim=-1)
         else:
-            out = torch.stack([freq, dlnf, amp,
+            out = torch.stack([f_start, f_end, amp,
                                torch.cos(ps), torch.sin(ps),
                                torch.cos(pe), torch.sin(pe)], dim=-1)
 


### PR DESCRIPTION
## Summary
- Token format changes from `[freq, dlnf, amp, phase_start, phase_end]` to `[f_start, f_end, amp, phase_start, phase_end]`
- Both frequency and phase are now defined at half-window boundaries, making the representation symmetric
- `f_end[w] ≈ f_start[w+1]` for clean signals, matching the existing phase tiling property
- Simpler for a transformer to consume: direct boundary values instead of center + rate

## Changes
- `ToneTokenizer.forward()`: computes `f_start = freq * exp(-dlnf/2)`, `f_end = freq * exp(dlnf/2)`
- `ToneTokenEmbedding._embed()`: reads `f_start`, `f_end` directly (no logic change needed)
- Docs updated

## Test plan
- [x] End-to-end smoke test: ToneTokenizer -> ToneTokenEmbedding -> TransformerEmbedding produces correct shapes
- [x] `python examples/spectral_demo.py` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)