### PR TITLE
Expand tone tokens with boundary amplitudes and phase corrections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ The `dlnf` parameter is per-hop and internally scaled by 2 for the full window. 
 
 ### `src/fuge/spectral/embedding.py` — `ToneTokenEmbedding(nn.Module)`
 
-Transforms raw tone tokens (f_start, f_end, amp, phase_start, phase_end) into model-ready embedded features with z-score normalization.
+Transforms raw tone tokens (snr, t_start, t_end, f_start, f_end, A_start, A_end, phase_start, phase_end) into model-ready embedded features with z-score normalization. SNR is peak amplitude from the (optionally whitened) STFT. Time and frequency boundaries tile the signal; boundary amplitudes are recovered via weighted FFTs with complementary time weights.
 
 ### `src/fuge/svd/core.py` — `StreamingPCA(nn.Module)`
 

--- a/examples/merger_reconstruction_demo.py
+++ b/examples/merger_reconstruction_demo.py
@@ -21,19 +21,19 @@ N = 10_000
 T_C_FRAC = 0.75          # coalescence at 3/4 of signal
 T_C = int(T_C_FRAC * N)  # sample index of coalescence
 
-F0 = 0.002               # initial frequency (cycles/sample)
+F0 = 0.001               # initial frequency (cycles/sample)
 F_RD = 0.01              # ringdown frequency (cycles/sample)
 CHIRP_RATE = (F_RD - F0) / T_C  # constant df/dt
 
-A0 = 0.2                 # amplitude scale
-AMP_EXPONENT = -0.80     # power-law index for inspiral amplitude
+A0 = 0.1                 # amplitude scale
+AMP_EXPONENT = -1.00     # power-law index for inspiral amplitude
 A_PEAK = 10.0             # peak amplitude at coalescence
 
 TAU_RD = 120.0           # ringdown e-folding time (samples)
 # ~50 oscillations in ringdown: 5*tau_rd * f_rd = 5*500*0.02 = 50
 
 # ── Tokenizer parameters ─────────────────────────────────────────────
-K_WINDOW = 512
+K_WINDOW = 256
 N_PEAKS = 1
 N_DLNF = 51
 DLNF_MIN = 0.0
@@ -158,6 +158,10 @@ def main():
         dlnf_min=DLNF_MIN, dlnf_max=DLNF_MAX,
     ).double()
 
+    # Get the dlnf=0 STFT (same as what goes into peak search)
+    X0 = tokenizer.decomposer(x, dlnf=0.0)  # (1, W, k)
+    stft_mag = X0[0, :, :K_WINDOW // 2 + 1].abs().numpy()  # (W, Fk)
+
     tokens = tokenizer(x)  # (1, W, K, 9)
     tokens = tokens[0].numpy()  # (W, K, 9)
     W, K, _ = tokens.shape
@@ -210,14 +214,19 @@ def main():
     ax_bl.legend(fontsize=8)
     ax_bl.grid(True, alpha=0.3)
 
-    # Bottom right: residual spectrogram
+    # Bottom right: tokenizer STFT at dlnf=0
     ax_br = fig.add_subplot(gs[1, 1])
-    ax_br.specgram(residual, NFFT=K_WINDOW, Fs=1.0, noverlap=K_WINDOW // 2,
-                   cmap='magma', scale='dB')
+    hop = K_WINDOW // 2
+    Fk = K_WINDOW // 2 + 1
+    t_wins = np.arange(stft_mag.shape[0]) * hop + K_WINDOW / 2  # window centers
+    f_bins = np.arange(Fk) / K_WINDOW  # cycles/sample
+    ax_br.pcolormesh(t_wins, f_bins, 20 * np.log10(stft_mag.T + 1e-12),
+                     cmap='magma', shading='nearest')
     ax_br.axvline(T_C, color='w', ls=':', lw=1, alpha=0.7)
+    ax_br.set_ylim(0, 5 * F_RD)
     ax_br.set_xlabel("Sample")
     ax_br.set_ylabel("Frequency (cycles/sample)")
-    ax_br.set_title("Residual spectrogram")
+    ax_br.set_title("DechirpSTFT magnitude (dlnf=0)")
 
     out = "merger_reconstruction_demo.png"
     plt.savefig(out, dpi=150)

--- a/examples/merger_reconstruction_demo.py
+++ b/examples/merger_reconstruction_demo.py
@@ -1,0 +1,228 @@
+"""Merger reconstruction demo.
+
+Generates a toy black-hole-merger-like signal (chirp inspiral with
+power-law amplitude rise, followed by exponential ringdown), tokenizes
+it, reconstructs from tokens, and compares with the original.
+"""
+
+import sys
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+
+import jax
+jax.config.update("jax_enable_x64", True)
+
+sys.path.insert(0, ".")
+from fuge.spectral import ToneTokenizer
+
+# ── Signal parameters ────────────────────────────────────────────────
+N = 10_000
+T_C_FRAC = 0.75          # coalescence at 3/4 of signal
+T_C = int(T_C_FRAC * N)  # sample index of coalescence
+
+F0 = 0.002               # initial frequency (cycles/sample)
+F_RD = 0.01              # ringdown frequency (cycles/sample)
+CHIRP_RATE = (F_RD - F0) / T_C  # constant df/dt
+
+A0 = 0.2                 # amplitude scale
+AMP_EXPONENT = -0.80     # power-law index for inspiral amplitude
+A_PEAK = 10.0             # peak amplitude at coalescence
+
+TAU_RD = 120.0           # ringdown e-folding time (samples)
+# ~50 oscillations in ringdown: 5*tau_rd * f_rd = 5*500*0.02 = 50
+
+# ── Tokenizer parameters ─────────────────────────────────────────────
+K_WINDOW = 512
+N_PEAKS = 1
+N_DLNF = 51
+DLNF_MIN = 0.0
+DLNF_MAX = 0.3
+
+
+def make_merger_signal(N, t_c, f0, chirp_rate, f_rd, A0, amp_exp, A_peak, tau_rd):
+    """Generate a merger-like signal: chirp inspiral + exponential ringdown."""
+    t = np.arange(N, dtype=np.float64)
+    signal = np.zeros(N)
+
+    # --- Inspiral phase (t < t_c) ---
+    mask_insp = t < t_c
+    t_insp = t[mask_insp]
+
+    # Frequency: f(t) = f0 + chirp_rate * t
+    phi_insp = 2.0 * np.pi * (f0 * t_insp + 0.5 * chirp_rate * t_insp**2)
+
+    # Amplitude: power-law rise, capped at A_peak
+    # A(t) = A0 * (1 - t/t_c)^amp_exp, but clamp so it doesn't exceed A_peak
+    tau = np.maximum(1.0 - t_insp / t_c, 1e-6)
+    A_insp = np.minimum(A0 * tau ** amp_exp, A_peak)
+
+    signal[mask_insp] = A_insp * np.cos(phi_insp)
+
+    # Phase at coalescence
+    phi_c = 2.0 * np.pi * (f0 * t_c + 0.5 * chirp_rate * t_c**2)
+
+    # --- Ringdown phase (t >= t_c) ---
+    mask_rd = t >= t_c
+    t_rd = t[mask_rd] - t_c
+
+    phi_rd = phi_c + 2.0 * np.pi * f_rd * t_rd
+    A_rd = A_peak * np.exp(-t_rd / tau_rd)
+
+    signal[mask_rd] = A_rd * np.cos(phi_rd)
+
+    return signal
+
+
+def reconstruct_from_tokens(tokens, k, N_signal):
+    """Reconstruct a time-domain signal from tone tokens via overlap-add.
+
+    Parameters
+    ----------
+    tokens : ndarray, shape (W, K, 9)
+        Token array: [snr, t_start, t_end, f_start, f_end,
+                       A_start, A_end, phase_start, phase_end].
+    k : int
+        Window size.
+    N_signal : int
+        Output signal length.
+    """
+    hop = k // 2
+    W, K, _ = tokens.shape
+    Fk = k // 2 + 1
+
+    n = np.arange(k)
+    frac = (n - k / 4) / (k / 2)
+
+    window = torch.hann_window(k, dtype=torch.float64).numpy()
+
+    signal = np.zeros(N_signal)
+    norm = np.zeros(N_signal)
+
+    for w in range(W):
+        start = w * hop
+        end = start + k
+        if end > N_signal:
+            break
+
+        window_signal = np.zeros(k)
+
+        for p in range(K):
+            snr = tokens[w, p, 0]
+            if snr <= 0:
+                continue
+
+            f_start_bin = (tokens[w, p, 3] + 1.0) / 2.0 * (Fk - 1)
+            f_end_bin = (tokens[w, p, 4] + 1.0) / 2.0 * (Fk - 1)
+
+            A_s = tokens[w, p, 5]
+            A_e = tokens[w, p, 6]
+            ps = tokens[w, p, 7]
+            pe = tokens[w, p, 8]
+
+            A_n = A_s + (A_e - A_s) * frac
+
+            dphi = pe - ps
+            f_center_bin = (f_start_bin + f_end_bin) / 2
+            expected_dphi = np.pi * f_center_bin
+            n_wraps = np.round((expected_dphi - dphi) / (2 * np.pi))
+            dphi_unwrapped = dphi + n_wraps * 2 * np.pi
+
+            df = f_end_bin - f_start_bin
+            phi_n = (ps + dphi_unwrapped * frac
+                     + (np.pi / 2) * df * frac * (frac - 1))
+
+            window_signal += A_n * np.cos(phi_n)
+
+        signal[start:end] += window_signal * window
+        norm[start:end] += window
+
+    mask = norm > 1e-12
+    signal[mask] /= norm[mask]
+
+    return signal
+
+
+def main():
+    # Generate signal
+    print("Generating merger signal...")
+    signal = make_merger_signal(
+        N, T_C, F0, CHIRP_RATE, F_RD, A0, AMP_EXPONENT, A_PEAK, TAU_RD,
+    )
+    x = torch.from_numpy(signal).unsqueeze(0)  # (1, N)
+
+    # Tokenize
+    print("Tokenizing...")
+    tokenizer = ToneTokenizer(
+        k=K_WINDOW, n_peaks=N_PEAKS, n_dlnf=N_DLNF,
+        dlnf_min=DLNF_MIN, dlnf_max=DLNF_MAX,
+    ).double()
+
+    tokens = tokenizer(x)  # (1, W, K, 9)
+    tokens = tokens[0].numpy()  # (W, K, 9)
+    W, K, _ = tokens.shape
+    print(f"  {W} windows, {K} peaks/window")
+
+    # Reconstruct
+    print("Reconstructing from tokens...")
+    recon = reconstruct_from_tokens(tokens, K_WINDOW, N)
+
+    # Compute residual
+    residual = signal - recon
+    margin = K_WINDOW
+
+    # SNR by region
+    sl = slice(margin, N - margin)
+    rms_s = np.sqrt(np.mean(signal[sl] ** 2))
+    rms_r = np.sqrt(np.mean(residual[sl] ** 2))
+    snr = 20 * np.log10(rms_s / rms_r) if rms_r > 0 else np.inf
+    print(f"  Reconstruction SNR: {snr:.1f} dB")
+
+    # ── Plot ──────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(18, 10), constrained_layout=True)
+    gs = fig.add_gridspec(2, 2, height_ratios=[1.2, 1])
+
+    fig.suptitle(
+        f"Merger reconstruction  (k={K_WINDOW}, {N_PEAKS} peaks, "
+        f"SNR={snr:.1f} dB)",
+        fontsize=13)
+
+    t = np.arange(N)
+
+    # Top: full signal comparison (wide panel)
+    ax_top = fig.add_subplot(gs[0, :])
+    ax_top.plot(t, signal, 'b-', lw=0.6, alpha=0.8, label='Original')
+    ax_top.plot(t, recon, 'r--', lw=0.6, alpha=0.8, label='Reconstructed')
+    ax_top.axvline(T_C, color='k', ls=':', lw=1, alpha=0.5, label=f'Coalescence (t={T_C})')
+    ax_top.set_xlabel("Sample")
+    ax_top.set_ylabel("Amplitude")
+    ax_top.set_title("Full signal: inspiral + merger + ringdown")
+    ax_top.legend(fontsize=9, loc='upper left')
+    ax_top.grid(True, alpha=0.3)
+
+    # Bottom left: residual over time
+    ax_bl = fig.add_subplot(gs[1, 0])
+    ax_bl.plot(t, residual, 'g-', lw=0.3, alpha=0.7)
+    ax_bl.axvline(T_C, color='k', ls=':', lw=1, alpha=0.5, label='Coalescence')
+    ax_bl.set_xlabel("Sample")
+    ax_bl.set_ylabel("Residual")
+    ax_bl.set_title("Residual (original - reconstructed)")
+    ax_bl.legend(fontsize=8)
+    ax_bl.grid(True, alpha=0.3)
+
+    # Bottom right: residual spectrogram
+    ax_br = fig.add_subplot(gs[1, 1])
+    ax_br.specgram(residual, NFFT=K_WINDOW, Fs=1.0, noverlap=K_WINDOW // 2,
+                   cmap='magma', scale='dB')
+    ax_br.axvline(T_C, color='w', ls=':', lw=1, alpha=0.7)
+    ax_br.set_xlabel("Sample")
+    ax_br.set_ylabel("Frequency (cycles/sample)")
+    ax_br.set_title("Residual spectrogram")
+
+    out = "merger_reconstruction_demo.png"
+    plt.savefig(out, dpi=150)
+    print(f"Saved {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/multiresolution_demo.py
+++ b/examples/multiresolution_demo.py
@@ -1,0 +1,403 @@
+"""Multi-resolution token reconstruction demo.
+
+Generates a merger signal with noise, tokenizes at multiple window sizes
+(64, 128, ..., 1024), greedily selects the best-SNR tokens across
+resolutions, and reconstructs from the multi-resolution token set.
+
+The greedy algorithm:
+  1. Start from the finest resolution (k_min) — its tokens tile the full
+     time axis via hop = k_min/2.
+  2. For each coarser resolution k (in ascending order), each token covers
+     k/k_min fine-grid slots.  If the coarse token's SNR exceeds the
+     combined SNR of the sub-tokens it would replace (power addition:
+     sqrt(sum(snr_i^2))), the coarse token wins and replaces them.
+  3. The result is a multi-resolution tiling: short windows near
+     coalescence (fast changes), long windows in the quiet inspiral
+     (better frequency resolution).
+"""
+
+import sys
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+
+import jax
+jax.config.update("jax_enable_x64", True)
+
+sys.path.insert(0, ".")
+from fuge.spectral import ToneTokenizer
+
+# ── Signal parameters ────────────────────────────────────────────────
+N = 8192
+T_C_FRAC = 0.75
+T_C = int(T_C_FRAC * N)
+
+F0 = 0.001
+F_RD = 0.01
+CHIRP_RATE = (F_RD - F0) / T_C
+
+A0 = 0.1
+AMP_EXPONENT = -1.00
+A_PEAK = 10.0
+
+TAU_RD = 120.0
+
+F_MAX = 2 * F_RD         # maximum frequency for peak selection
+
+NOISE_SIGMA = 1.0
+
+# ── Tokenizer parameters ─────────────────────────────────────────────
+K_VALUES = [64, 128, 256, 512, 1024, 2048, 4096]
+N_PEAKS = 1
+N_DLNF = 51
+DLNF_MIN = 0.0
+DLNF_MAX = 0.3
+
+SEED = 42
+
+
+def make_merger_signal(N, t_c, f0, chirp_rate, f_rd, A0, amp_exp, A_peak, tau_rd):
+    """Generate a merger-like signal: chirp inspiral + exponential ringdown."""
+    t = np.arange(N, dtype=np.float64)
+    signal = np.zeros(N)
+
+    mask_insp = t < t_c
+    t_insp = t[mask_insp]
+    phi_insp = 2.0 * np.pi * (f0 * t_insp + 0.5 * chirp_rate * t_insp**2)
+    tau = np.maximum(1.0 - t_insp / t_c, 1e-6)
+    A_insp = np.minimum(A0 * tau ** amp_exp, A_peak)
+    signal[mask_insp] = A_insp * np.cos(phi_insp)
+
+    phi_c = 2.0 * np.pi * (f0 * t_c + 0.5 * chirp_rate * t_c**2)
+    mask_rd = t >= t_c
+    t_rd = t[mask_rd] - t_c
+    phi_rd = phi_c + 2.0 * np.pi * f_rd * t_rd
+    A_rd = A_peak * np.exp(-t_rd / tau_rd)
+    signal[mask_rd] = A_rd * np.cos(phi_rd)
+
+    return signal
+
+
+def tokenize_multi(signal, k_values, n_peaks, n_dlnf, dlnf_min, dlnf_max,
+                    f_max=None):
+    """Tokenize at multiple window sizes. Returns dict k -> (W, K, 9).
+
+    If f_max is given (in cycles/sample), tokens with center frequency
+    above f_max have their SNR zeroed out so they are ignored.
+    """
+    x = torch.from_numpy(signal).unsqueeze(0)
+    tokens_by_k = {}
+    for k in k_values:
+        tokenizer = ToneTokenizer(
+            k=k, n_peaks=n_peaks, n_dlnf=n_dlnf,
+            dlnf_min=dlnf_min, dlnf_max=dlnf_max,
+        ).double()
+        tok = tokenizer(x)[0].numpy()  # (W, K, 9)
+
+        if f_max is not None:
+            # f_start, f_end are in [-1, 1] mapping to [0, Fk-1] bins
+            # Convert f_max to normalized token units
+            Fk = k // 2 + 1
+            f_max_bin = f_max * k  # cycles/sample -> bin index
+            f_max_norm = 2.0 * f_max_bin / (Fk - 1) - 1.0
+            # Zero SNR for peaks whose center frequency exceeds f_max
+            f_center = (tok[:, :, 3] + tok[:, :, 4]) / 2
+            above = f_center > f_max_norm
+            tok[above, 0] = 0.0
+            n_killed = np.sum(above)
+            n_total = tok.shape[0] * tok.shape[1]
+            print(f"  k={k:4d}: {tok.shape[0]} windows "
+                  f"({n_killed}/{n_total} peaks above f_max={f_max:.4f})")
+        else:
+            print(f"  k={k:4d}: {tok.shape[0]} windows")
+
+        tokens_by_k[k] = tok
+    return tokens_by_k
+
+
+def greedy_select(tokens_by_k, k_values):
+    """Greedy multi-resolution token selection.
+
+    Returns a list of (k, window_idx, token_data) for each unique selected
+    token, plus the assignment array mapping fine slots -> token index.
+    """
+    k_min = min(k_values)
+    hop_min = k_min // 2
+
+    # Best peak per window at finest resolution
+    tok_fine = tokens_by_k[k_min]  # (W_fine, K, 9)
+    W_fine = tok_fine.shape[0]
+
+    # Per fine slot: track (k, window_idx, snr, token_vector)
+    slot_k = np.full(W_fine, k_min, dtype=int)
+    slot_w = np.arange(W_fine, dtype=int)
+    best_peaks = np.argmax(tok_fine[:, :, 0], axis=1)
+    slot_snr = np.array([tok_fine[w, best_peaks[w], 0] for w in range(W_fine)])
+    slot_token = np.array([tok_fine[w, best_peaks[w], :] for w in range(W_fine)])
+
+    # Upgrade through coarser resolutions
+    for k in sorted(k_values):
+        if k == k_min:
+            continue
+
+        tok = tokens_by_k[k]
+        ratio = k // k_min  # fine slots per coarse window
+
+        for w in range(tok.shape[0]):
+            best_p = np.argmax(tok[w, :, 0])
+            coarse_snr = tok[w, best_p, 0]
+
+            fine_start = w * ratio
+            fine_end = fine_start + ratio
+            if fine_end > W_fine:
+                continue
+
+            # Combined SNR of current sub-tokens (power addition)
+            combined_snr = np.sqrt(np.sum(slot_snr[fine_start:fine_end] ** 2))
+
+            if coarse_snr > combined_snr:
+                slot_k[fine_start:fine_end] = k
+                slot_w[fine_start:fine_end] = w
+                slot_snr[fine_start:fine_end] = coarse_snr
+                slot_token[fine_start:fine_end] = tok[w, best_p, :]
+
+    return slot_k, slot_w, slot_snr, slot_token, W_fine
+
+
+def _synthesize_window(tok, k):
+    """Synthesize a full k-sample waveform from a single token."""
+    Fk = k // 2 + 1
+    n = np.arange(k)
+    frac = (n - k / 4) / (k / 2)
+
+    if tok[0] <= 0:  # snr
+        return np.zeros(k)
+
+    f_start_bin = (tok[3] + 1.0) / 2.0 * (Fk - 1)
+    f_end_bin = (tok[4] + 1.0) / 2.0 * (Fk - 1)
+    A_s, A_e = tok[5], tok[6]
+    ps, pe = tok[7], tok[8]
+
+    A_n = A_s + (A_e - A_s) * frac
+
+    dphi = pe - ps
+    f_center_bin = (f_start_bin + f_end_bin) / 2
+    expected_dphi = np.pi * f_center_bin
+    n_wraps = np.round((expected_dphi - dphi) / (2 * np.pi))
+    dphi_unwrapped = dphi + n_wraps * 2 * np.pi
+
+    df = f_end_bin - f_start_bin
+    phi_n = (ps + dphi_unwrapped * frac
+             + (np.pi / 2) * df * frac * (frac - 1))
+
+    return A_n * np.cos(phi_n)
+
+
+def _reconstruct_single_k(tokens_k, k, N_signal):
+    """Standard COLA overlap-add reconstruction for a single window size."""
+    hop = k // 2
+    W = tokens_k.shape[0]
+    window = torch.hann_window(k, dtype=torch.float64).numpy()
+    signal = np.zeros(N_signal)
+    norm = np.zeros(N_signal)
+
+    for w in range(W):
+        start = w * hop
+        end = start + k
+        if end > N_signal:
+            break
+        # Use best peak
+        best_p = np.argmax(tokens_k[w, :, 0])
+        wave = _synthesize_window(tokens_k[w, best_p, :], k)
+        signal[start:end] += wave * window
+        norm[start:end] += window
+
+    mask = norm > 1e-12
+    signal[mask] /= norm[mask]
+    return signal
+
+
+def reconstruct_multiresolution(slot_k, slot_w, slot_token, k_min, W_fine,
+                                N_signal, tokens_by_k, k_values):
+    """Reconstruct by blending per-resolution COLA reconstructions.
+
+    1. Reconstruct each resolution independently via standard COLA.
+    2. For each fine time slot, use the signal from the selected resolution.
+    3. Cross-fade at resolution boundaries.
+    """
+    hop_min = k_min // 2
+
+    # Full COLA reconstruction per k
+    recon_by_k = {}
+    for k in k_values:
+        recon_by_k[k] = _reconstruct_single_k(tokens_by_k[k], k, N_signal)
+
+    # Build output: pick from selected resolution per fine slot
+    signal = np.zeros(N_signal)
+    for i in range(W_fine):
+        k = int(slot_k[i])
+        out_start = i * hop_min
+        out_end = min(out_start + hop_min, N_signal)
+        signal[out_start:out_end] = recon_by_k[k][out_start:out_end]
+
+    # Cross-fade at resolution boundaries
+    for i in range(1, W_fine):
+        if slot_k[i] == slot_k[i - 1]:
+            continue
+        boundary = i * hop_min
+        fade_len = hop_min  # cross-fade over one fine hop
+        b_start = max(boundary - fade_len // 2, 0)
+        b_end = min(boundary + fade_len // 2, N_signal)
+        n = b_end - b_start
+        if n < 2:
+            continue
+        fade_in = 0.5 * (1 - np.cos(np.pi * np.arange(n) / n))
+        fade_out = 1 - fade_in
+        k_left = int(slot_k[i - 1])
+        k_right = int(slot_k[i])
+        signal[b_start:b_end] = (fade_out * recon_by_k[k_left][b_start:b_end]
+                                 + fade_in * recon_by_k[k_right][b_start:b_end])
+
+    return signal
+
+
+def main():
+    rng = np.random.default_rng(SEED)
+
+    # Generate signal
+    print("Generating merger signal...")
+    signal_clean = make_merger_signal(
+        N, T_C, F0, CHIRP_RATE, F_RD, A0, AMP_EXPONENT, A_PEAK, TAU_RD,
+    )
+    noise = rng.standard_normal(N) * NOISE_SIGMA
+    signal = signal_clean + noise
+
+    # Tokenize at multiple resolutions
+    print("Tokenizing at multiple resolutions...")
+    tokens_by_k = tokenize_multi(
+        signal, K_VALUES, N_PEAKS, N_DLNF, DLNF_MIN, DLNF_MAX,
+        f_max=F_MAX,
+    )
+
+    # Greedy selection
+    print("Greedy multi-resolution selection...")
+    k_min = min(K_VALUES)
+    slot_k, slot_w, slot_snr, slot_token, W_fine = greedy_select(
+        tokens_by_k, K_VALUES,
+    )
+
+    # Report selection statistics
+    for k in K_VALUES:
+        count = np.sum(slot_k == k)
+        print(f"  k={k:4d}: {count:3d} fine slots ({count * 100 / W_fine:.0f}%)")
+
+    # Reconstruct
+    print("Reconstructing from multi-resolution tokens...")
+    recon = reconstruct_multiresolution(
+        slot_k, slot_w, slot_token, k_min, W_fine, N,
+        tokens_by_k, K_VALUES,
+    )
+
+    # Also reconstruct single-resolution for comparison (finest k)
+    recon_fine = _reconstruct_single_k(tokens_by_k[k_min], k_min, N)
+
+    # SNR
+    margin = max(K_VALUES)
+    sl = slice(margin, N - margin)
+
+    residual = signal_clean - recon
+    rms_s = np.sqrt(np.mean(signal_clean[sl] ** 2))
+    rms_r = np.sqrt(np.mean(residual[sl] ** 2))
+    snr_multi = 20 * np.log10(rms_s / rms_r) if rms_r > 0 else np.inf
+
+    residual_fine = signal_clean - recon_fine
+    rms_r_fine = np.sqrt(np.mean(residual_fine[sl] ** 2))
+    snr_fine = 20 * np.log10(rms_s / rms_r_fine) if rms_r_fine > 0 else np.inf
+
+    print(f"  Multi-resolution SNR: {snr_multi:.1f} dB")
+    print(f"  Fine-only (k={k_min}) SNR: {snr_fine:.1f} dB")
+
+    # ── Plot ──────────────────────────────────────────────────────────
+    fig = plt.figure(figsize=(18, 14), constrained_layout=True)
+    gs = fig.add_gridspec(3, 2, height_ratios=[1.2, 0.5, 1])
+
+    fig.suptitle(
+        f"Multi-resolution reconstruction  "
+        f"(k={K_VALUES}, noise_sigma={NOISE_SIGMA})\n"
+        f"Multi-res SNR={snr_multi:.1f} dB vs "
+        f"fine-only (k={k_min}) SNR={snr_fine:.1f} dB",
+        fontsize=13)
+
+    t = np.arange(N)
+
+    # Row 0: full signal comparison (wide panel)
+    ax_top = fig.add_subplot(gs[0, :])
+    ax_top.plot(t, signal, color='0.75', lw=0.3, alpha=0.5, label='Noisy input')
+    ax_top.plot(t, signal_clean, 'b-', lw=0.5, alpha=0.7, label='Original (clean)')
+    ax_top.plot(t, recon, 'r-', lw=0.5, alpha=0.7, label='Multi-res reconstruction')
+    ax_top.axvline(T_C, color='k', ls=':', lw=1, alpha=0.5, label=f'Coalescence')
+    ymax = np.max(np.abs(signal_clean)) * 1.2
+    ax_top.set_ylim(-ymax, ymax)
+    ax_top.set_xlabel("Sample")
+    ax_top.set_ylabel("Amplitude")
+    ax_top.set_title("Signal and multi-resolution reconstruction")
+    ax_top.legend(fontsize=9, loc='upper left')
+    ax_top.grid(True, alpha=0.3)
+
+    # Row 1: resolution map (wide panel)
+    ax_res = fig.add_subplot(gs[1, :])
+    hop_min = k_min // 2
+    # Color-code by selected k
+    k_colors = {k: plt.cm.viridis(i / (len(K_VALUES) - 1))
+                for i, k in enumerate(K_VALUES)}
+    for i in range(W_fine):
+        k = slot_k[i]
+        x0 = i * hop_min
+        ax_res.barh(0, hop_min, left=x0, height=1,
+                    color=k_colors[k], edgecolor='none')
+    ax_res.axvline(T_C, color='k', ls=':', lw=1, alpha=0.5)
+    ax_res.set_xlim(0, N)
+    ax_res.set_yticks([])
+    ax_res.set_xlabel("Sample")
+    ax_res.set_title("Selected window size per time slot")
+    patches = [mpatches.Patch(color=k_colors[k], label=f'k={k}')
+               for k in K_VALUES]
+    ax_res.legend(handles=patches, fontsize=8, loc='upper right', ncol=len(K_VALUES))
+
+    # Row 2 left: residual comparison
+    ax_bl = fig.add_subplot(gs[2, 0])
+    ax_bl.plot(t, residual_fine, 'c-', lw=0.3, alpha=0.5,
+               label=f'Fine-only (k={k_min})')
+    ax_bl.plot(t, residual, 'g-', lw=0.3, alpha=0.7,
+               label='Multi-resolution')
+    ax_bl.axvline(T_C, color='k', ls=':', lw=1, alpha=0.5)
+    ax_bl.set_xlabel("Sample")
+    ax_bl.set_ylabel("Residual")
+    ax_bl.set_title("Residual (original - reconstructed)")
+    ax_bl.legend(fontsize=8)
+    ax_bl.grid(True, alpha=0.3)
+
+    # Row 2 right: SNR per fine slot
+    ax_br = fig.add_subplot(gs[2, 1])
+    t_slots = np.arange(W_fine) * hop_min + hop_min / 2
+    ax_br.plot(t_slots, slot_snr, 'k-', lw=0.5, alpha=0.7)
+    # Color the background by selected k
+    for i in range(W_fine):
+        k = slot_k[i]
+        x0 = i * hop_min
+        ax_br.axvspan(x0, x0 + hop_min, alpha=0.15, color=k_colors[k],
+                      edgecolor='none')
+    ax_br.axvline(T_C, color='k', ls=':', lw=1, alpha=0.5)
+    ax_br.set_xlabel("Sample")
+    ax_br.set_ylabel("Token SNR")
+    ax_br.set_title("Selected token SNR (background = window size)")
+    ax_br.grid(True, alpha=0.3)
+
+    out = "multiresolution_demo.png"
+    plt.savefig(out, dpi=150)
+    print(f"Saved {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/token_continuity_demo.py
+++ b/examples/token_continuity_demo.py
@@ -1,0 +1,182 @@
+"""Token boundary continuity demo.
+
+Generates a chirp signal, tokenizes it, and plots the continuity of
+boundary quantities across adjacent windows:
+  - f_end[w] vs f_start[w+1]
+  - A_end[w] vs A_start[w+1]
+  - phase_end[w] vs phase_start[w+1]
+
+For a clean (noiseless) signal these should match closely.  The plots
+show both the raw values over time and the boundary mismatch histograms.
+"""
+
+import sys
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+
+import jax
+jax.config.update("jax_enable_x64", True)
+
+sys.path.insert(0, ".")
+from chirp import chirp_signal
+from fuge.spectral import ToneTokenizer
+
+# ── Signal parameters ────────────────────────────────────────────────
+N = 100_000
+F0 = 2.75e-3
+CHIRP_MASS = 1.0
+T_C = 1e6
+A0 = 5.0
+HARMONIC_DECAY = 1.5
+N_HARMONICS = 4
+NOISE_SIGMA = 0.5
+
+# ── Tokenizer parameters ─────────────────────────────────────────────
+K_WINDOW = 1024
+N_PEAKS = 1       # single strongest peak per window for cleaner plots
+N_DLNF = 11
+DLNF_MIN = 0.0
+DLNF_MAX = 0.05
+
+SEED = 42
+
+
+def main():
+    rng = np.random.default_rng(SEED)
+
+    # Generate signal
+    print("Generating chirp signal...")
+    signal = chirp_signal(
+        f0=F0, chirp_mass=CHIRP_MASS, t_c=T_C, A0=A0,
+        harmonic_decay=HARMONIC_DECAY, n_harmonics=N_HARMONICS, N=N,
+    )
+    noise = rng.standard_normal(N) * NOISE_SIGMA
+    x = torch.from_numpy(signal + noise).unsqueeze(0)  # (1, N)
+
+    # Tokenize
+    print("Tokenizing...")
+    tokenizer = ToneTokenizer(
+        k=K_WINDOW, n_peaks=N_PEAKS, n_dlnf=N_DLNF,
+        dlnf_min=DLNF_MIN, dlnf_max=DLNF_MAX,
+    ).double()
+
+    tokens = tokenizer(x)  # (1, W, K, 9)
+    tokens = tokens[0, :, 0, :]  # (W, 9) — first (only) peak
+    W = tokens.shape[0]
+    print(f"  {W} windows, token shape per peak: {tokens.shape}")
+
+    # Extract fields: [snr, t_start, t_end, f_start, f_end, A_start, A_end, ps, pe]
+    snr = tokens[:, 0].numpy()
+    t_start = tokens[:, 1].numpy()
+    t_end = tokens[:, 2].numpy()
+    f_start = tokens[:, 3].numpy()
+    f_end = tokens[:, 4].numpy()
+    A_start = tokens[:, 5].numpy()
+    A_end = tokens[:, 6].numpy()
+    ps = tokens[:, 7].numpy()
+    pe = tokens[:, 8].numpy()
+
+    # Window center time for x-axis
+    t_center = (t_start + t_end) / 2
+
+    # Boundary differences: end[w] - start[w+1]
+    df = f_end[:-1] - f_start[1:]
+    dA = A_end[:-1] - A_start[1:]
+    # Phase difference mod 2*pi
+    dphi = pe[:-1] - ps[1:]
+    dphi = (dphi + np.pi) % (2 * np.pi) - np.pi  # wrap to [-pi, pi]
+    t_boundary = t_end[:-1]
+
+    # ── Plot ──────────────────────────────────────────────────────────
+    fig, axes = plt.subplots(3, 3, figsize=(18, 12))
+    fig.suptitle(
+        f"Token boundary continuity  (k={K_WINDOW}, noise_sigma={NOISE_SIGMA})",
+        fontsize=14, y=0.98)
+
+    # --- Row 0: Frequency ---
+    ax = axes[0, 0]
+    ax.plot(t_center, f_start, '.', ms=2, alpha=0.5, label='f_start')
+    ax.plot(t_center, f_end, '.', ms=2, alpha=0.5, label='f_end')
+    ax.set_xlabel("Time (normalized)")
+    ax.set_ylabel("Frequency (normalized)")
+    ax.set_title("Frequency boundaries over time")
+    ax.legend(fontsize=8, markerscale=3)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[0, 1]
+    ax.plot(t_boundary, df, '.', ms=2, alpha=0.5, color='C2')
+    ax.axhline(0, color='k', ls='--', lw=0.5)
+    ax.set_xlabel("Time (normalized)")
+    ax.set_ylabel("f_end[w] - f_start[w+1]")
+    ax.set_title("Frequency boundary mismatch")
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[0, 2]
+    ax.hist(df, bins=50, color='C2', alpha=0.7, edgecolor='black', linewidth=0.5)
+    ax.axvline(0, color='k', ls='--', lw=0.5)
+    ax.set_xlabel("f_end[w] - f_start[w+1]")
+    ax.set_ylabel("Count")
+    ax.set_title(f"Freq mismatch histogram (std={np.std(df):.4f})")
+    ax.grid(True, alpha=0.3)
+
+    # --- Row 1: Amplitude ---
+    ax = axes[1, 0]
+    ax.plot(t_center, A_start, '.', ms=2, alpha=0.5, label='A_start')
+    ax.plot(t_center, A_end, '.', ms=2, alpha=0.5, label='A_end')
+    ax.set_xlabel("Time (normalized)")
+    ax.set_ylabel("Amplitude")
+    ax.set_title("Amplitude boundaries over time")
+    ax.legend(fontsize=8, markerscale=3)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[1, 1]
+    ax.plot(t_boundary, dA, '.', ms=2, alpha=0.5, color='C3')
+    ax.axhline(0, color='k', ls='--', lw=0.5)
+    ax.set_xlabel("Time (normalized)")
+    ax.set_ylabel("A_end[w] - A_start[w+1]")
+    ax.set_title("Amplitude boundary mismatch")
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[1, 2]
+    ax.hist(dA, bins=50, color='C3', alpha=0.7, edgecolor='black', linewidth=0.5)
+    ax.axvline(0, color='k', ls='--', lw=0.5)
+    ax.set_xlabel("A_end[w] - A_start[w+1]")
+    ax.set_ylabel("Count")
+    ax.set_title(f"Amplitude mismatch histogram (std={np.std(dA):.4f})")
+    ax.grid(True, alpha=0.3)
+
+    # --- Row 2: Phase ---
+    ax = axes[2, 0]
+    ax.plot(t_center, ps, '.', ms=2, alpha=0.5, label='phase_start')
+    ax.plot(t_center, pe, '.', ms=2, alpha=0.5, label='phase_end')
+    ax.set_xlabel("Time (normalized)")
+    ax.set_ylabel("Phase (rad)")
+    ax.set_title("Phase boundaries over time")
+    ax.legend(fontsize=8, markerscale=3)
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[2, 1]
+    ax.plot(t_boundary, dphi, '.', ms=2, alpha=0.5, color='C4')
+    ax.axhline(0, color='k', ls='--', lw=0.5)
+    ax.set_xlabel("Time (normalized)")
+    ax.set_ylabel("phase_end[w] - phase_start[w+1]")
+    ax.set_title("Phase boundary mismatch")
+    ax.grid(True, alpha=0.3)
+
+    ax = axes[2, 2]
+    ax.hist(dphi, bins=50, color='C4', alpha=0.7, edgecolor='black', linewidth=0.5)
+    ax.axvline(0, color='k', ls='--', lw=0.5)
+    ax.set_xlabel("phase_end[w] - phase_start[w+1] (rad)")
+    ax.set_ylabel("Count")
+    ax.set_title(f"Phase mismatch histogram (std={np.std(dphi):.4f})")
+    ax.grid(True, alpha=0.3)
+
+    plt.tight_layout()
+    out = "token_continuity_demo.png"
+    plt.savefig(out, dpi=150)
+    print(f"Saved {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/token_reconstruction_demo.py
+++ b/examples/token_reconstruction_demo.py
@@ -25,12 +25,12 @@ from fuge.spectral import ToneTokenizer
 
 # ── Signal parameters ────────────────────────────────────────────────
 N = 100_000
-F0 = 2.75e-3
-CHIRP_MASS = 1.0
+F0 = 2.75e-4
+CHIRP_MASS = 5.0
 T_C = 1e6
 A0 = 5.0
 HARMONIC_DECAY = 1.5
-N_HARMONICS = 4
+N_HARMONICS = 1
 NOISE_SIGMA = 0.0  # noiseless for clean reconstruction test
 
 # ── Tokenizer parameters ─────────────────────────────────────────────

--- a/examples/token_reconstruction_demo.py
+++ b/examples/token_reconstruction_demo.py
@@ -92,11 +92,8 @@ def reconstruct_from_tokens(tokens, k, N_signal):
             f_start_bin = (tokens[w, p, 3] + 1.0) / 2.0 * (Fk - 1)
             f_end_bin = (tokens[w, p, 4] + 1.0) / 2.0 * (Fk - 1)
 
-            # Factor of 2: FFT of w(n)*A*cos(...) gives |X| = A*sum(w)/2
-            # but the mixing matrix uses sum(w*basis) without the 1/2,
-            # so recovered amplitudes are half the true time-domain value.
-            A_s = tokens[w, p, 5] * 2.0
-            A_e = tokens[w, p, 6] * 2.0
+            A_s = tokens[w, p, 5]
+            A_e = tokens[w, p, 6]
             ps = tokens[w, p, 7]
             pe = tokens[w, p, 8]
 

--- a/examples/token_reconstruction_demo.py
+++ b/examples/token_reconstruction_demo.py
@@ -4,8 +4,9 @@ Generates a chirp signal, tokenizes it, reconstructs the signal from
 tokens alone using overlap-add synthesis, and compares with the original.
 
 Reconstruction per window per peak:
-  1. Linearly interpolate phase from phase_start (at sample k/4)
-     to phase_end (at sample 3k/4), extrapolate to window edges.
+  1. Quadratically interpolate phase from phase_start (at sample k/4)
+     to phase_end (at sample 3k/4), using f_start/f_end to account
+     for frequency chirp within the window.
   2. Linearly interpolate amplitude from A_start to A_end similarly.
   3. Synthesize: s(n) = A(n) * cos(phi(n))
   4. Apply Hann window, overlap-add.
@@ -30,15 +31,15 @@ CHIRP_MASS = 5.0
 T_C = 1e6
 A0 = 5.0
 HARMONIC_DECAY = 1.5
-N_HARMONICS = 1
+N_HARMONICS = 4
 NOISE_SIGMA = 0.0  # noiseless for clean reconstruction test
 
 # ── Tokenizer parameters ─────────────────────────────────────────────
 K_WINDOW = 1024
-N_PEAKS = 4
-N_DLNF = 11
+N_PEAKS = 5
+N_DLNF = 101
 DLNF_MIN = 0.0
-DLNF_MAX = 0.05
+DLNF_MAX = 0.5
 
 SEED = 42
 
@@ -111,8 +112,13 @@ def reconstruct_from_tokens(tokens, k, N_signal):
             n_wraps = np.round((expected_dphi - dphi) / (2 * np.pi))
             dphi_unwrapped = dphi + n_wraps * 2 * np.pi
 
-            # Linear phase interpolation
-            phi_n = ps + dphi_unwrapped * frac  # (k,)
+            # Quadratic phase interpolation: accounts for frequency
+            # change within the window.  The correction term is zero at
+            # the boundary anchors (frac=0 and frac=1) and maximal at
+            # the window center (frac=0.5).
+            df = f_end_bin - f_start_bin
+            phi_n = (ps + dphi_unwrapped * frac
+                     + (np.pi / 2) * df * frac * (frac - 1))  # (k,)
 
             window_signal += A_n * np.cos(phi_n)
 
@@ -202,8 +208,10 @@ def main():
 
     # Zoomed comparison — late (harder region)
     ax = axes[0, 1]
-    z2_start = int(0.85 * N)
-    z2 = slice(z2_start, z2_start + 6 * K_WINDOW)
+    z2_start = int(0.95 * N)
+    #z2 = slice(z2_start, z2_start + 6 * K_WINDOW)
+    #z2 = slice(z2_start, z2_start + 1 * K_WINDOW)
+    z2 = slice(z2_start, z2_start + 200)
     ax.plot(t[z2], signal_clean[z2], 'b-', lw=0.8, alpha=0.8, label='Original')
     ax.plot(t[z2], recon[z2], 'r--', lw=0.8, alpha=0.8, label='Reconstructed')
     ax.set_xlabel("Sample")

--- a/examples/token_reconstruction_demo.py
+++ b/examples/token_reconstruction_demo.py
@@ -209,14 +209,12 @@ def main():
     # Zoomed comparison — late (harder region)
     ax = axes[0, 1]
     z2_start = int(0.95 * N)
-    #z2 = slice(z2_start, z2_start + 6 * K_WINDOW)
-    #z2 = slice(z2_start, z2_start + 1 * K_WINDOW)
-    z2 = slice(z2_start, z2_start + 200)
+    z2 = slice(z2_start, z2_start + 6 * K_WINDOW)
     ax.plot(t[z2], signal_clean[z2], 'b-', lw=0.8, alpha=0.8, label='Original')
     ax.plot(t[z2], recon[z2], 'r--', lw=0.8, alpha=0.8, label='Reconstructed')
     ax.set_xlabel("Sample")
     ax.set_ylabel("Amplitude")
-    ax.set_title("Late region (6 windows at t=85%)")
+    ax.set_title("Late region (6 windows at t=95%)")
     ax.legend(fontsize=8)
     ax.grid(True, alpha=0.3)
 

--- a/examples/token_reconstruction_demo.py
+++ b/examples/token_reconstruction_demo.py
@@ -1,0 +1,243 @@
+"""Token reconstruction demo.
+
+Generates a chirp signal, tokenizes it, reconstructs the signal from
+tokens alone using overlap-add synthesis, and compares with the original.
+
+Reconstruction per window per peak:
+  1. Linearly interpolate phase from phase_start (at sample k/4)
+     to phase_end (at sample 3k/4), extrapolate to window edges.
+  2. Linearly interpolate amplitude from A_start to A_end similarly.
+  3. Synthesize: s(n) = A(n) * cos(phi(n))
+  4. Apply Hann window, overlap-add.
+"""
+
+import sys
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+
+import jax
+jax.config.update("jax_enable_x64", True)
+
+sys.path.insert(0, ".")
+from chirp import chirp_signal
+from fuge.spectral import ToneTokenizer
+
+# ── Signal parameters ────────────────────────────────────────────────
+N = 100_000
+F0 = 2.75e-3
+CHIRP_MASS = 1.0
+T_C = 1e6
+A0 = 5.0
+HARMONIC_DECAY = 1.5
+N_HARMONICS = 4
+NOISE_SIGMA = 0.0  # noiseless for clean reconstruction test
+
+# ── Tokenizer parameters ─────────────────────────────────────────────
+K_WINDOW = 1024
+N_PEAKS = 4
+N_DLNF = 11
+DLNF_MIN = 0.0
+DLNF_MAX = 0.05
+
+SEED = 42
+
+
+def reconstruct_from_tokens(tokens, k, N_signal):
+    """Reconstruct a time-domain signal from tone tokens via overlap-add.
+
+    Parameters
+    ----------
+    tokens : ndarray, shape (W, K, 9)
+        Token array: [snr, t_start, t_end, f_start, f_end,
+                       A_start, A_end, phase_start, phase_end].
+    k : int
+        Window size.
+    N_signal : int
+        Output signal length.
+
+    Returns
+    -------
+    signal : ndarray, shape (N_signal,)
+    """
+    hop = k // 2
+    W, K, _ = tokens.shape
+    Fk = k // 2 + 1
+
+    # Sample indices within a window
+    n = np.arange(k)
+    # Fractional position: 0 at k/4, 1 at 3k/4
+    frac = (n - k / 4) / (k / 2)  # (k,)
+
+    # Must match torch.hann_window (periodic=True by default)
+    window = torch.hann_window(k, dtype=torch.float64).numpy()
+
+    signal = np.zeros(N_signal)
+    norm = np.zeros(N_signal)
+
+    for w in range(W):
+        start = w * hop
+        end = start + k
+        if end > N_signal:
+            break
+
+        window_signal = np.zeros(k)
+
+        for p in range(K):
+            snr = tokens[w, p, 0]
+            if snr <= 0:
+                continue
+
+            # Denormalize frequencies from [-1, 1] to bin indices
+            f_start_bin = (tokens[w, p, 3] + 1.0) / 2.0 * (Fk - 1)
+            f_end_bin = (tokens[w, p, 4] + 1.0) / 2.0 * (Fk - 1)
+
+            # Factor of 2: FFT of w(n)*A*cos(...) gives |X| = A*sum(w)/2
+            # but the mixing matrix uses sum(w*basis) without the 1/2,
+            # so recovered amplitudes are half the true time-domain value.
+            A_s = tokens[w, p, 5] * 2.0
+            A_e = tokens[w, p, 6] * 2.0
+            ps = tokens[w, p, 7]
+            pe = tokens[w, p, 8]
+
+            # Linearly interpolate amplitude
+            A_n = A_s + (A_e - A_s) * frac  # (k,)
+
+            # Phase interpolation: unwrap the phase difference
+            dphi = pe - ps
+            # The total phase advance from k/4 to 3k/4 should be
+            # close to 2*pi*f_center * (k/2) / k = pi*f_center_bin
+            # Use frequency to resolve wrapping ambiguity
+            f_center_bin = (f_start_bin + f_end_bin) / 2
+            expected_dphi = np.pi * f_center_bin  # 2*pi*f*(k/2)/k
+            # Find the multiple of 2*pi closest to expected
+            n_wraps = np.round((expected_dphi - dphi) / (2 * np.pi))
+            dphi_unwrapped = dphi + n_wraps * 2 * np.pi
+
+            # Linear phase interpolation
+            phi_n = ps + dphi_unwrapped * frac  # (k,)
+
+            window_signal += A_n * np.cos(phi_n)
+
+        # Overlap-add with Hann synthesis window.
+        # COLA property: sum of shifted Hann windows = 1.0 in interior,
+        # so we normalize by sum(window) not sum(window^2).
+        signal[start:end] += window_signal * window
+        norm[start:end] += window
+
+    # Normalize by window overlap (avoid division by zero at edges)
+    mask = norm > 1e-12
+    signal[mask] /= norm[mask]
+
+    return signal
+
+
+def main():
+    rng = np.random.default_rng(SEED)
+
+    # Generate signal
+    print("Generating chirp signal...")
+    signal_clean = chirp_signal(
+        f0=F0, chirp_mass=CHIRP_MASS, t_c=T_C, A0=A0,
+        harmonic_decay=HARMONIC_DECAY, n_harmonics=N_HARMONICS, N=N,
+    )
+    noise = rng.standard_normal(N) * NOISE_SIGMA
+    signal = signal_clean + noise
+    x = torch.from_numpy(signal).unsqueeze(0)  # (1, N)
+
+    # Tokenize
+    print("Tokenizing...")
+    tokenizer = ToneTokenizer(
+        k=K_WINDOW, n_peaks=N_PEAKS, n_dlnf=N_DLNF,
+        dlnf_min=DLNF_MIN, dlnf_max=DLNF_MAX,
+    ).double()
+
+    tokens = tokenizer(x)  # (1, W, K, 9)
+    tokens = tokens[0].numpy()  # (W, K, 9)
+    W, K, _ = tokens.shape
+    print(f"  {W} windows, {K} peaks/window")
+
+    # Reconstruct
+    print("Reconstructing from tokens...")
+    recon = reconstruct_from_tokens(tokens, K_WINDOW, N)
+
+    # Compute residual
+    residual = signal_clean - recon
+    margin = K_WINDOW
+
+    # SNR by region
+    regions = {
+        "full": slice(margin, N - margin),
+        "first 90%": slice(margin, int(0.9 * N)),
+        "last 10%": slice(int(0.9 * N), N - margin),
+    }
+    snr_by_region = {}
+    print("  Reconstruction SNR by region:")
+    for label, sl in regions.items():
+        rms_s = np.sqrt(np.mean(signal_clean[sl] ** 2))
+        rms_r = np.sqrt(np.mean(residual[sl] ** 2))
+        snr = 20 * np.log10(rms_s / rms_r) if rms_r > 0 else np.inf
+        snr_by_region[label] = snr
+        print(f"    {label:12s}: {snr:.1f} dB  (signal RMS={rms_s:.3f}, residual RMS={rms_r:.4f})")
+
+    # ── Plot ──────────────────────────────────────────────────────────
+    fig, axes = plt.subplots(2, 2, figsize=(18, 12))
+    fig.suptitle(
+        f"Token reconstruction  (k={K_WINDOW}, {N_PEAKS} peaks, "
+        f"noise_sigma={NOISE_SIGMA})\n"
+        f"SNR: full={snr_by_region['full']:.1f} dB, "
+        f"first 90%={snr_by_region['first 90%']:.1f} dB, "
+        f"last 10%={snr_by_region['last 10%']:.1f} dB",
+        fontsize=13, y=1.0)
+
+    t = np.arange(N)
+
+    # Zoomed comparison — early (good region)
+    ax = axes[0, 0]
+    z1 = slice(N // 4, N // 4 + 6 * K_WINDOW)
+    ax.plot(t[z1], signal_clean[z1], 'b-', lw=0.8, alpha=0.8, label='Original')
+    ax.plot(t[z1], recon[z1], 'r--', lw=0.8, alpha=0.8, label='Reconstructed')
+    ax.set_xlabel("Sample")
+    ax.set_ylabel("Amplitude")
+    ax.set_title("Early region (6 windows at t=25%)")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    # Zoomed comparison — late (harder region)
+    ax = axes[0, 1]
+    z2_start = int(0.85 * N)
+    z2 = slice(z2_start, z2_start + 6 * K_WINDOW)
+    ax.plot(t[z2], signal_clean[z2], 'b-', lw=0.8, alpha=0.8, label='Original')
+    ax.plot(t[z2], recon[z2], 'r--', lw=0.8, alpha=0.8, label='Reconstructed')
+    ax.set_xlabel("Sample")
+    ax.set_ylabel("Amplitude")
+    ax.set_title("Late region (6 windows at t=85%)")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    # Residual over time
+    ax = axes[1, 0]
+    ax.plot(t, residual, 'g-', lw=0.3, alpha=0.7)
+    ax.axvline(0.9 * N, color='k', ls='--', lw=1, alpha=0.5, label='90% mark')
+    ax.set_xlabel("Sample")
+    ax.set_ylabel("Residual")
+    ax.set_title("Residual (original - reconstructed)")
+    ax.legend(fontsize=8)
+    ax.grid(True, alpha=0.3)
+
+    # Residual spectrogram
+    ax = axes[1, 1]
+    ax.specgram(residual, NFFT=K_WINDOW, Fs=1.0, noverlap=K_WINDOW // 2,
+                cmap='magma', scale='dB')
+    ax.set_xlabel("Sample")
+    ax.set_ylabel("Frequency (cycles/sample)")
+    ax.set_title("Residual spectrogram")
+
+    plt.tight_layout()
+    out = "token_reconstruction_demo.png"
+    plt.savefig(out, dpi=150)
+    print(f"Saved {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/fuge/spectral/core.py
+++ b/src/fuge/spectral/core.py
@@ -437,12 +437,35 @@ class DechirpSTFT(nn.Module):
         f_delta = freq_ref - freq_idx.float()
         phi_0 = X_peak.angle() - torch.pi * f_delta * (self.k - 1) / self.k
 
-        # Advance to half-window boundaries using freq_refined (bin units).
-        # phase(n) = phi_0 + 2*pi * freq * n / k
-        # phase_start at n = k/4:  phi_0 + pi * freq / 2
-        # phase_end   at n = 3k/4: phi_0 + 3 * pi * freq / 2
-        phase_start = (phi_0 + torch.pi * freq_ref / 2).reshape(B, W, K)
-        phase_end = (phi_0 + 3 * torch.pi * freq_ref / 2).reshape(B, W, K)
+        # Advance to half-window boundaries via the dechirp warping.
+        #
+        # phi_0 is the phase at sample 0, extracted from the dechirped FFT.
+        # In the dechirped domain, the signal is a pure tone at freq_ref,
+        # so the phase at dechirped position tau in [0, 1] is:
+        #   phi_dechirp(tau) = phi_0 + 2*pi * freq_ref * tau
+        #
+        # The dechirp resampling maps original sample position n to
+        # dechirped position:
+        #   tau(n) = (exp(beta * n/k) - 1) / (exp(beta) - 1)
+        # where beta = 2 * dlnf_applied (the grid value used for dechirping).
+        #
+        # For beta -> 0 this reduces to tau = n/k (identity), giving the
+        # linear formula phi_0 + 2*pi*freq*n/k.
+        dlnf_applied = dlnf_grid[dlnf_idx]  # (BW, K) — the actual dechirp used
+        beta = 2.0 * dlnf_applied
+        small = beta.abs() < 1e-8
+        beta_safe = torch.where(small, torch.ones_like(beta), beta)
+        eb = torch.exp(beta_safe)
+
+        def _phase_at(n_frac):
+            """Phase at original sample n_frac * k, via dechirp mapping."""
+            tau = (torch.exp(beta_safe * n_frac) - 1.0) / (eb - 1.0)
+            warped_adv = 2.0 * torch.pi * freq_ref * tau
+            linear_adv = 2.0 * torch.pi * freq_ref * n_frac
+            return torch.where(small, linear_adv, warped_adv)
+
+        phase_start = (phi_0 + _phase_at(0.25)).reshape(B, W, K)
+        phase_end = (phi_0 + _phase_at(0.75)).reshape(B, W, K)
 
         if not batched:
             phase_start = phase_start.squeeze(0)

--- a/src/fuge/spectral/core.py
+++ b/src/fuge/spectral/core.py
@@ -309,6 +309,15 @@ class DechirpSTFT(nn.Module):
         pooled = F.max_pool2d(amp_4d, kernel_size=kernel, stride=1, padding=radius)
         is_peak = (amp_4d == pooled).squeeze(1)  # (BW, D, F)
 
+        # Collapse duplicate peaks along the dlnf axis: for each frequency
+        # bin, keep only the dlnf index with the highest amplitude.  This
+        # prevents a slowly-chirping signal (flat dlnf response) from
+        # producing multiple peaks at the same frequency.
+        best_d = amp.argmax(dim=1, keepdim=True)  # (BW, 1, Fk)
+        dlnf_mask = torch.zeros_like(is_peak)
+        dlnf_mask.scatter_(1, best_d, 1)
+        is_peak = is_peak & dlnf_mask.bool()
+
         # Keep only peak amplitudes, flatten spatial dims
         amp_peaks = torch.where(is_peak, amp, torch.zeros_like(amp))
         amp_flat = amp_peaks.reshape(BW, -1)  # (BW, D*F)

--- a/src/fuge/spectral/core.py
+++ b/src/fuge/spectral/core.py
@@ -47,6 +47,25 @@ class DechirpSTFT(nn.Module):
         ])
         self.register_buffer("amp_unmix", torch.linalg.inv(M))
 
+        # Precompute scalloping correction lookup table for weighted windows.
+        # At fractional bin offset delta, the FFT magnitude is reduced by
+        # |DTFT(w, delta)| / |DTFT(w, 0)|.  We store the inverse of this
+        # ratio on a dense grid for fast interpolation at runtime.
+        # w_start and w_end have nearly identical scalloping (Hann symmetry),
+        # so we compute from w_start and use for both.
+        n_lut = 64  # half-bin resolution: 0 to 0.5
+        delta_lut = torch.linspace(0, 0.5, n_lut)
+        ns = torch.arange(k, dtype=torch.float64)
+        w_ref = self.window_start.double()
+        dtft_mag = torch.zeros(n_lut)
+        for i, d in enumerate(delta_lut):
+            phasor = torch.exp(2j * torch.pi * d * ns / k)
+            dtft_mag[i] = (w_ref * phasor).sum().abs()
+        # Normalize: correction = mag_at_0 / mag_at_delta
+        scallop_lut = dtft_mag[0] / dtft_mag.clamp(min=1e-12)
+        self.register_buffer("_scallop_lut", scallop_lut.float())
+        self.register_buffer("_scallop_delta_max", torch.tensor(0.5))
+
     def forward(self, x: torch.Tensor, a: float = 0.0, dlnf=0.0,
                 return_weighted: bool = False):
         """Compute the (de-chirped) windowed FFT.
@@ -394,14 +413,37 @@ class DechirpSTFT(nn.Module):
 
         return phase_start, phase_end
 
+    def _scallop_correction(self, delta: torch.Tensor) -> torch.Tensor:
+        """Look up scalloping correction factor from precomputed table.
+
+        Parameters
+        ----------
+        delta : Tensor
+            Fractional bin offset (signed); only |delta| matters.
+
+        Returns
+        -------
+        correction : Tensor, same shape as delta.
+            Multiply FFT magnitude at integer bin by this to recover
+            the on-bin magnitude.
+        """
+        lut = self._scallop_lut  # (n_lut,) on [0, 0.5]
+        n_lut = lut.shape[0]
+        # Map |delta| to LUT index space [0, n_lut-1]
+        t = delta.abs().clamp(max=0.5) * (n_lut - 1) / 0.5
+        idx_lo = t.long().clamp(max=n_lut - 2)
+        frac = t - idx_lo.float()
+        return lut[idx_lo] * (1 - frac) + lut[idx_lo + 1] * frac
+
     def peak_amplitudes(self, X_start: torch.Tensor, X_end: torch.Tensor,
-                        peaks: torch.Tensor,
+                        peaks: torch.Tensor, freq_refined: torch.Tensor,
                         ) -> tuple[torch.Tensor, torch.Tensor]:
         """Extract boundary amplitudes (A_start, A_end) from weighted FFTs.
 
         Uses the precomputed inverse mixing matrix to deconvolve the
         weighted FFT magnitudes into true boundary amplitudes, assuming
-        linear amplitude variation within each window.
+        linear amplitude variation within each window.  Corrects for
+        Hann-window scalloping loss at fractional frequency bin offsets.
 
         Parameters
         ----------
@@ -409,6 +451,9 @@ class DechirpSTFT(nn.Module):
             Weighted FFTs from forward(..., return_weighted=True).
         peaks : LongTensor, shape ([B,] N_WINDOWS, K, 2)
             Integer (dlnf_idx, freq_idx) from find_peaks.
+        freq_refined : Tensor, shape ([B,] N_WINDOWS, K)
+            Parabolic-interpolated fractional frequency bin index from
+            find_peaks, used to correct for scalloping loss.
 
         Returns
         -------
@@ -420,6 +465,7 @@ class DechirpSTFT(nn.Module):
             X_start = X_start.unsqueeze(1)
             X_end = X_end.unsqueeze(1)
             peaks = peaks.unsqueeze(0)
+            freq_refined = freq_refined.unsqueeze(0)
 
         D, B, W, k_full = X_start.shape
         Fk = self.k // 2 + 1
@@ -436,6 +482,12 @@ class DechirpSTFT(nn.Module):
         flat_idx = dlnf_idx * Fk + freq_idx  # (BW, K)
         mag_s = amp_s.gather(1, flat_idx)  # (BW, K)
         mag_e = amp_e.gather(1, flat_idx)  # (BW, K)
+
+        # Correct for scalloping loss at fractional bin offset
+        delta = freq_refined.reshape(B * W, K) - freq_idx.float()
+        scallop_corr = self._scallop_correction(delta)
+        mag_s = mag_s * scallop_corr
+        mag_e = mag_e * scallop_corr
 
         # Apply inverse mixing matrix: [A_start, A_end] = amp_unmix @ [mag_s, mag_e]
         M_inv = self.amp_unmix  # (2, 2)
@@ -602,7 +654,7 @@ class ToneTokenizer(nn.Module):
         ps, pe = self.decomposer.peak_phases(
             X, peaks, freq, dlnf, self.dlnf_grid)
         A_start, A_end = self.decomposer.peak_amplitudes(
-            X_start, X_end, peaks)
+            X_start, X_end, peaks, freq)
 
         # Time at half-window boundaries: sample k/4 and 3k/4 per window
         k = self.decomposer.k

--- a/src/fuge/spectral/core.py
+++ b/src/fuge/spectral/core.py
@@ -38,7 +38,9 @@ class DechirpSTFT(nn.Module):
         self.register_buffer("window_start", (1 - t_unit) * window)
         self.register_buffer("window_end", t_unit * window)
 
-        # Precompute 2x2 mixing matrix and its inverse
+        # Precompute 2x2 mixing matrix and its inverse.
+        # The mixing matrix relates weighted FFT magnitudes to boundary
+        # amplitudes, assuming linear A(t) within the window.
         basis_start = 1 - t_unit
         basis_end = t_unit
         M = torch.tensor([
@@ -54,17 +56,15 @@ class DechirpSTFT(nn.Module):
         # w_start and w_end have nearly identical scalloping (Hann symmetry),
         # so we compute from w_start and use for both.
         n_lut = 64  # half-bin resolution: 0 to 0.5
-        delta_lut = torch.linspace(0, 0.5, n_lut)
         ns = torch.arange(k, dtype=torch.float64)
+        delta_lut = torch.linspace(0, 0.5, n_lut)
         w_ref = self.window_start.double()
         dtft_mag = torch.zeros(n_lut)
         for i, d in enumerate(delta_lut):
             phasor = torch.exp(2j * torch.pi * d * ns / k)
             dtft_mag[i] = (w_ref * phasor).sum().abs()
-        # Normalize: correction = mag_at_0 / mag_at_delta
         scallop_lut = dtft_mag[0] / dtft_mag.clamp(min=1e-12)
         self.register_buffer("_scallop_lut", scallop_lut.float())
-        self.register_buffer("_scallop_delta_max", torch.tensor(0.5))
 
         # Precompute parabolic interpolation correction LUT.
         # Parabolic interpolation on Hann-windowed data systematically
@@ -499,6 +499,10 @@ class DechirpSTFT(nn.Module):
         linear amplitude variation within each window.  Corrects for
         Hann-window scalloping loss at fractional frequency bin offsets.
 
+        The output amplitudes are true time-domain amplitudes (the 1/2
+        factor from the cosine→complex exponential decomposition in the
+        FFT is corrected for).
+
         Parameters
         ----------
         X_start, X_end : complex Tensor, shape (D, N_WINDOWS, k) or (D, B, N_WINDOWS, k)
@@ -544,9 +548,11 @@ class DechirpSTFT(nn.Module):
         mag_e = mag_e * scallop_corr
 
         # Apply inverse mixing matrix: [A_start, A_end] = amp_unmix @ [mag_s, mag_e]
+        # Then multiply by 2 to correct for the cosine→complex exponential
+        # factor of 1/2 in the FFT magnitudes.
         M_inv = self.amp_unmix  # (2, 2)
-        A_start = M_inv[0, 0] * mag_s + M_inv[0, 1] * mag_e
-        A_end = M_inv[1, 0] * mag_s + M_inv[1, 1] * mag_e
+        A_start = 2.0 * (M_inv[0, 0] * mag_s + M_inv[0, 1] * mag_e)
+        A_end = 2.0 * (M_inv[1, 0] * mag_s + M_inv[1, 1] * mag_e)
 
         A_start = A_start.clamp(min=0.0).reshape(B, W, K)
         A_end = A_end.clamp(min=0.0).reshape(B, W, K)

--- a/src/fuge/spectral/core.py
+++ b/src/fuge/spectral/core.py
@@ -66,6 +66,33 @@ class DechirpSTFT(nn.Module):
         self.register_buffer("_scallop_lut", scallop_lut.float())
         self.register_buffer("_scallop_delta_max", torch.tensor(0.5))
 
+        # Precompute parabolic interpolation correction LUT.
+        # Parabolic interpolation on Hann-windowed data systematically
+        # underestimates fractional bin offsets (e.g. true 0.4 -> estimated 0.36).
+        # We precompute the exact forward mapping true_delta -> para_delta using
+        # the known Hann DTFT, then store the inverse for runtime correction.
+        n_corr = 1000  # dense forward mapping
+        true_d = torch.linspace(0, 0.5, n_corr, dtype=torch.float64)
+        para_d = torch.zeros(n_corr, dtype=torch.float64)
+        w_hann = self.window.double()
+        for i, td in enumerate(true_d):
+            mags = []
+            for off in [-1, 0, 1]:
+                phasor = torch.exp(2j * torch.pi * (off - td) * ns / k)
+                mags.append((w_hann * phasor).sum().abs())
+            ym, y0, yp = mags
+            denom = ym - 2.0 * y0 + yp
+            para_d[i] = 0.5 * (ym - yp) / denom if denom.abs() > 1e-12 else 0.0
+        # Invert: uniform grid over parabolic delta -> true delta
+        n_inv = 64
+        para_grid = torch.linspace(0, 0.5, n_inv, dtype=torch.float64)
+        # numpy interp for inversion (monotonic)
+        import numpy as _np
+        true_inv = _np.interp(
+            para_grid.numpy(), para_d.numpy(), true_d.numpy())
+        self.register_buffer(
+            "_para_corr_lut", torch.from_numpy(true_inv).float())
+
     def forward(self, x: torch.Tensor, a: float = 0.0, dlnf=0.0,
                 return_weighted: bool = False):
         """Compute the (de-chirped) windowed FFT.
@@ -308,6 +335,7 @@ class DechirpSTFT(nn.Module):
         f_delta = 0.5 * (yf_m - yf_p) / f_denom
         f_delta = torch.where(f_denom.abs() < 1e-12, torch.zeros_like(f_delta), f_delta)
         f_delta = f_delta.clamp(-0.5, 0.5)
+        f_delta = self._correct_parabolic(f_delta)
         freq_refined = fi.float() + f_delta
 
         # --- Parabolic interpolation along dlnf axis ---
@@ -412,6 +440,32 @@ class DechirpSTFT(nn.Module):
             phase_end = phase_end.squeeze(0)
 
         return phase_start, phase_end
+
+    def _correct_parabolic(self, delta: torch.Tensor) -> torch.Tensor:
+        """Correct parabolic interpolation bias using precomputed LUT.
+
+        Parabolic interpolation systematically underestimates fractional
+        bin offsets for Hann windows.  This method maps the biased estimate
+        to the true offset using an exact inverse mapping.
+
+        Parameters
+        ----------
+        delta : Tensor
+            Signed parabolic estimate of fractional bin offset.
+
+        Returns
+        -------
+        corrected : Tensor, same shape as delta.
+        """
+        lut = self._para_corr_lut  # (n_inv,) on [0, 0.5]
+        n_inv = lut.shape[0]
+        sign = delta.sign()
+        ad = delta.abs().clamp(max=0.5)
+        t = ad * (n_inv - 1) / 0.5
+        idx_lo = t.long().clamp(max=n_inv - 2)
+        frac = t - idx_lo.float()
+        corrected = lut[idx_lo] * (1 - frac) + lut[idx_lo + 1] * frac
+        return sign * corrected
 
     def _scallop_correction(self, delta: torch.Tensor) -> torch.Tensor:
         """Look up scalloping correction factor from precomputed table.

--- a/src/fuge/spectral/core.py
+++ b/src/fuge/spectral/core.py
@@ -32,7 +32,23 @@ class DechirpSTFT(nn.Module):
         # Normalized time coordinate: t in [-1, +1] across the window
         self.register_buffer("t_norm", torch.linspace(-1.0, 1.0, k))
 
-    def forward(self, x: torch.Tensor, a: float = 0.0, dlnf=0.0) -> torch.Tensor:
+        # Weighted windows for amplitude-at-boundary estimation
+        t_unit = torch.linspace(0, 1, k)
+        window = torch.hann_window(k)
+        self.register_buffer("window_start", (1 - t_unit) * window)
+        self.register_buffer("window_end", t_unit * window)
+
+        # Precompute 2x2 mixing matrix and its inverse
+        basis_start = 1 - t_unit
+        basis_end = t_unit
+        M = torch.tensor([
+            [(self.window_start * basis_start).sum(), (self.window_start * basis_end).sum()],
+            [(self.window_end * basis_start).sum(), (self.window_end * basis_end).sum()],
+        ])
+        self.register_buffer("amp_unmix", torch.linalg.inv(M))
+
+    def forward(self, x: torch.Tensor, a: float = 0.0, dlnf=0.0,
+                return_weighted: bool = False):
         """Compute the (de-chirped) windowed FFT.
 
         Parameters
@@ -48,12 +64,17 @@ class DechirpSTFT(nn.Module):
             If a 1-D Tensor, computes the STFT for each value in parallel;
             output gains a leading D dimension.
             dlnf = 0 disables.
+        return_weighted : bool
+            If True, also return weighted FFTs for amplitude boundary
+            estimation.  Returns (X, X_start, X_end).
 
         Returns
         -------
         X : complex Tensor
             Scalar dlnf: shape (N_WINDOWS, k) or (B, N_WINDOWS, k).
             Batched dlnf: shape (D, N_WINDOWS, k) or (D, B, N_WINDOWS, k).
+        X_start, X_end : complex Tensor (only if return_weighted=True)
+            Same shape as X, from (1-t)*hann and t*hann weighted windows.
         """
         squeeze = x.dim() == 1
         if squeeze:
@@ -65,24 +86,47 @@ class DechirpSTFT(nn.Module):
         # Apply Hann window
         windowed = windows * self.window
 
+        # Weighted windows for amplitude boundary estimation
+        if return_weighted:
+            windowed_start = windows * self.window_start
+            windowed_end = windows * self.window_end
+
         # --- Relative de-chirp via time-grid resampling ---
         # dlnf is per hop; full window spans 2 hops
         batched = isinstance(dlnf, torch.Tensor) and dlnf.dim() >= 1
         if batched:
             windowed = self._resample_dechirp_batched(windowed, 2.0 * dlnf)
-            # (D, B, N_WINDOWS, k)
+            if return_weighted:
+                windowed_start = self._resample_dechirp_batched(windowed_start, 2.0 * dlnf)
+                windowed_end = self._resample_dechirp_batched(windowed_end, 2.0 * dlnf)
         elif dlnf != 0.0:
             windowed = self._resample_dechirp(windowed, 2.0 * dlnf)
+            if return_weighted:
+                windowed_start = self._resample_dechirp(windowed_start, 2.0 * dlnf)
+                windowed_end = self._resample_dechirp(windowed_end, 2.0 * dlnf)
 
         # --- Absolute de-chirp via phase multiplication ---
         if a != 0.0:
             chirp_kernel = torch.exp(-1j * a * self.t_norm ** 2)
             windowed = windowed * chirp_kernel
+            if return_weighted:
+                windowed_start = windowed_start * chirp_kernel
+                windowed_end = windowed_end * chirp_kernel
 
         X = torch.fft.fft(windowed, n=self.k, dim=-1)
 
+        if return_weighted:
+            X_start = torch.fft.fft(windowed_start, n=self.k, dim=-1)
+            X_end = torch.fft.fft(windowed_end, n=self.k, dim=-1)
+
         if squeeze:
             X = X.squeeze(1) if batched else X.squeeze(0)
+            if return_weighted:
+                X_start = X_start.squeeze(1) if batched else X_start.squeeze(0)
+                X_end = X_end.squeeze(1) if batched else X_end.squeeze(0)
+
+        if return_weighted:
+            return X, X_start, X_end
         return X
 
     def _resample_dechirp(self, windowed: torch.Tensor, beta: float) -> torch.Tensor:
@@ -350,6 +394,63 @@ class DechirpSTFT(nn.Module):
 
         return phase_start, phase_end
 
+    def peak_amplitudes(self, X_start: torch.Tensor, X_end: torch.Tensor,
+                        peaks: torch.Tensor,
+                        ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Extract boundary amplitudes (A_start, A_end) from weighted FFTs.
+
+        Uses the precomputed inverse mixing matrix to deconvolve the
+        weighted FFT magnitudes into true boundary amplitudes, assuming
+        linear amplitude variation within each window.
+
+        Parameters
+        ----------
+        X_start, X_end : complex Tensor, shape (D, N_WINDOWS, k) or (D, B, N_WINDOWS, k)
+            Weighted FFTs from forward(..., return_weighted=True).
+        peaks : LongTensor, shape ([B,] N_WINDOWS, K, 2)
+            Integer (dlnf_idx, freq_idx) from find_peaks.
+
+        Returns
+        -------
+        A_start, A_end : Tensor, shape ([B,] N_WINDOWS, K)
+            Amplitude at window start and end boundaries, clamped >= 0.
+        """
+        batched = X_start.dim() == 4
+        if not batched:
+            X_start = X_start.unsqueeze(1)
+            X_end = X_end.unsqueeze(1)
+            peaks = peaks.unsqueeze(0)
+
+        D, B, W, k_full = X_start.shape
+        Fk = self.k // 2 + 1
+        K = peaks.shape[2]
+
+        # Flatten batch*window for gathering
+        dlnf_idx = peaks.reshape(B * W, K, 2)[:, :, 0]
+        freq_idx = peaks.reshape(B * W, K, 2)[:, :, 1]
+
+        # Rearrange: (D, B, W, k) -> (B, W, D, Fk) -> (BW, D*Fk)
+        amp_s = X_start[..., :Fk].abs().permute(1, 2, 0, 3).reshape(B * W, D * Fk)
+        amp_e = X_end[..., :Fk].abs().permute(1, 2, 0, 3).reshape(B * W, D * Fk)
+
+        flat_idx = dlnf_idx * Fk + freq_idx  # (BW, K)
+        mag_s = amp_s.gather(1, flat_idx)  # (BW, K)
+        mag_e = amp_e.gather(1, flat_idx)  # (BW, K)
+
+        # Apply inverse mixing matrix: [A_start, A_end] = amp_unmix @ [mag_s, mag_e]
+        M_inv = self.amp_unmix  # (2, 2)
+        A_start = M_inv[0, 0] * mag_s + M_inv[0, 1] * mag_e
+        A_end = M_inv[1, 0] * mag_s + M_inv[1, 1] * mag_e
+
+        A_start = A_start.clamp(min=0.0).reshape(B, W, K)
+        A_end = A_end.clamp(min=0.0).reshape(B, W, K)
+
+        if not batched:
+            A_start = A_start.squeeze(0)
+            A_end = A_end.squeeze(0)
+
+        return A_start, A_end
+
 
 class ToneTokenizer(nn.Module):
     """Tokenize time-domain signals into spectral peak features.
@@ -376,12 +477,19 @@ class ToneTokenizer(nn.Module):
 
     Output
     ------
-    forward(x) returns raw tokens of shape (B, N_WINDOWS, n_peaks, 5)
-    with 5 values per peak: [f_start, f_end, amp, phase_start, phase_end].
+    forward(x) returns raw tokens of shape (B, N_WINDOWS, n_peaks, 9)
+    with 9 values per peak: [snr, t_start, t_end, f_start, f_end, A_start,
+    A_end, phase_start, phase_end].
+    snr is the peak amplitude from the (optionally whitened) STFT — when
+    whitening is active this is a true signal-to-noise ratio.
+    t_start and t_end are sample positions at half-window boundaries (k/4 and
+    3k/4), normalized to [-1, 1] over the signal length.  For adjacent windows,
+    t_end[w] = t_start[w+1].
     f_start and f_end are normalized to [-1, 1] (mapping from [0, Fk-1] where
-    Fk = k // 2 + 1).  phase_start and phase_end are wrapped to [-pi, pi].
-    For adjacent windows, f_end[w] ≈ f_start[w+1] for clean signals.
-    When whitening is active, amp reflects SNR (amplitude / noise_std).
+    Fk = k // 2 + 1).  A_start and A_end are boundary amplitudes recovered
+    via weighted FFTs and mixing matrix inversion.  phase_start and phase_end
+    are wrapped to [-pi, pi].  For adjacent windows, f_end[w] ≈ f_start[w+1]
+    for clean signals.
     """
 
     def __init__(self, k: int = 1024, n_peaks: int = 3, radius: int = 2,
@@ -402,8 +510,8 @@ class ToneTokenizer(nn.Module):
 
     @property
     def n_raw(self):
-        """Number of raw features per peak token (always 5)."""
-        return 5
+        """Number of raw features per peak token (always 9)."""
+        return 9
 
     @torch.no_grad()
     def update_noise_std(self, x: torch.Tensor, momentum: float = 0.99) -> None:
@@ -465,26 +573,51 @@ class ToneTokenizer(nn.Module):
 
         Returns
         -------
-        tokens : Tensor, shape (B, W, K, 5) or (W, K, 5)
-            Values per peak: [f_start, f_end, amp, phase_start, phase_end].
+        tokens : Tensor, shape (B, W, K, 9) or (W, K, 9)
+            Values per peak: [snr, t_start, t_end, f_start, f_end, A_start,
+            A_end, phase_start, phase_end].
+            snr is peak amplitude (SNR when whitened).
+            t_start/t_end are normalized to [-1, 1] over signal length.
             f_start/f_end are normalized to [-1, 1].
+            A_start/A_end are boundary amplitudes.
             phase_start/phase_end are wrapped to [-pi, pi].
             W = number of time windows, K = n_peaks.
-            When whitening is active, amp is SNR (amplitude / noise_std).
         """
         squeeze = x.dim() == 1
         if squeeze:
             x = x.unsqueeze(0)
 
-        X = self.decomposer(x, dlnf=self.dlnf_grid)  # (D, B, W, k)
+        B, N = x.shape
+
+        X, X_start, X_end = self.decomposer(
+            x, dlnf=self.dlnf_grid, return_weighted=True)  # (D, B, W, k)
 
         if self.noise_std is not None:
             X = self._whiten(X)
+            X_start = self._whiten(X_start)
+            X_end = self._whiten(X_end)
 
-        peaks, freq, dlnf, amp = self.decomposer.find_peaks(
+        peaks, freq, dlnf, snr = self.decomposer.find_peaks(
             X, K=self.n_peaks, dlnf_grid=self.dlnf_grid, radius=self.radius)
         ps, pe = self.decomposer.peak_phases(
             X, peaks, freq, dlnf, self.dlnf_grid)
+        A_start, A_end = self.decomposer.peak_amplitudes(
+            X_start, X_end, peaks)
+
+        # Time at half-window boundaries: sample k/4 and 3k/4 per window
+        k = self.decomposer.k
+        hop = self.decomposer.hop
+        W = peaks.shape[-3]
+        w_idx = torch.arange(W, device=x.device, dtype=x.dtype)
+        # Absolute sample positions of boundaries
+        t_s = w_idx * hop + k // 4       # (W,)
+        t_e = w_idx * hop + 3 * k // 4   # (W,)
+        # Normalize to [-1, 1] over signal length
+        t_s = 2.0 * t_s / (N - 1) - 1.0
+        t_e = 2.0 * t_e / (N - 1) - 1.0
+        # Broadcast to match peak dims: (W,) -> (W, 1) -> matches (B, W, K)
+        t_start = t_s.unsqueeze(-1).expand_as(freq)
+        t_end = t_e.unsqueeze(-1).expand_as(freq)
 
         # Frequency at half-window boundaries (dlnf is per hop,
         # boundaries are ±0.5 hops from center)
@@ -500,7 +633,8 @@ class ToneTokenizer(nn.Module):
         ps = (ps + torch.pi) % (2 * torch.pi) - torch.pi
         pe = (pe + torch.pi) % (2 * torch.pi) - torch.pi
 
-        tokens = torch.stack([f_start, f_end, amp, ps, pe], dim=-1)  # (B, W, K, 5)
+        tokens = torch.stack(
+            [snr, t_start, t_end, f_start, f_end, A_start, A_end, ps, pe], dim=-1)
 
         if squeeze:
             tokens = tokens.squeeze(0)

--- a/src/fuge/spectral/embedding.py
+++ b/src/fuge/spectral/embedding.py
@@ -1,11 +1,14 @@
-"""Tone token embedding: raw (B, W, K, 5) tokens -> (B, W*K, n_embed).
+"""Tone token embedding: raw (B, W, K, 9) tokens -> (B, W*K, n_embed).
 
-Transforms raw tone features (f_start, f_end, amp, phase_start,
-phase_end) into model-ready embedded features with z-score normalization.
+Transforms raw tone features (snr, t_start, t_end, f_start, f_end,
+A_start, A_end, phase_start, phase_end) into model-ready embedded
+features with z-score normalization.
 
 Input token format (from ToneTokenizer):
+  snr: peak amplitude / noise std (log1p applied here)
+  t_start, t_end: normalized time in [-1, 1]
   f_start, f_end: normalized frequency in [-1, 1]
-  amp: amplitude (positive, unbounded; log1p applied here)
+  A_start, A_end: boundary amplitudes (positive, unbounded; log1p applied here)
   phase_start, phase_end: wrapped to [-pi, pi]
 """
 
@@ -16,19 +19,20 @@ import torch.nn as nn
 class ToneTokenEmbedding(nn.Module):
     """Embed raw spectral peak tokens into model-ready features.
 
-    Applies cos/sin to phases, log1p to amplitude, then z-score normalizes.
+    Applies log1p to snr and amplitudes, cos/sin to phases, passes time
+    and frequency through directly, then z-score normalizes.
     Each peak becomes an independent token in the output sequence.
 
     Parameters
     ----------
     phase_mode : str
-        "center": use (phase_start + phase_end) / 2  -> n_embed = 5
-        "boundary": keep both phase endpoints         -> n_embed = 7
+        "center": use (phase_start + phase_end) / 2  -> n_embed = 9
+        "boundary": keep both phase endpoints         -> n_embed = 11
     mask_phases : bool
         Zero out phase features (for ablation studies).
     """
 
-    N_EMBED = {"center": 5, "boundary": 7}
+    N_EMBED = {"center": 9, "boundary": 11}
 
     def __init__(self, phase_mode="center", mask_phases=False):
         super().__init__()
@@ -43,7 +47,7 @@ class ToneTokenEmbedding(nn.Module):
 
         Parameters
         ----------
-        raw_tokens : Tensor, shape (B, W, K, 5)
+        raw_tokens : Tensor, shape (B, W, K, 9)
         """
         embedded = self._embed(raw_tokens)
         flat = embedded.reshape(-1, self.n_embed)
@@ -53,25 +57,31 @@ class ToneTokenEmbedding(nn.Module):
     def _embed(self, raw_tokens):
         """Apply feature transforms (before z-scoring).
 
-        (B, W, K, 5) -> (B, W, K, n_embed)
+        (B, W, K, 9) -> (B, W, K, n_embed)
         """
-        f_start = raw_tokens[..., 0]
-        f_end = raw_tokens[..., 1]
-        amp = torch.log1p(raw_tokens[..., 2])
-        ps = raw_tokens[..., 3]
-        pe = raw_tokens[..., 4]
+        snr = torch.log1p(raw_tokens[..., 0])
+        t_start = raw_tokens[..., 1]
+        t_end = raw_tokens[..., 2]
+        f_start = raw_tokens[..., 3]
+        f_end = raw_tokens[..., 4]
+        a_start = torch.log1p(raw_tokens[..., 5])
+        a_end = torch.log1p(raw_tokens[..., 6])
+        ps = raw_tokens[..., 7]
+        pe = raw_tokens[..., 8]
 
         if self.phase_mode == "center":
             phi = (ps + pe) / 2
-            out = torch.stack([f_start, f_end, amp,
+            out = torch.stack([snr, t_start, t_end, f_start, f_end,
+                               a_start, a_end,
                                torch.cos(phi), torch.sin(phi)], dim=-1)
         else:
-            out = torch.stack([f_start, f_end, amp,
+            out = torch.stack([snr, t_start, t_end, f_start, f_end,
+                               a_start, a_end,
                                torch.cos(ps), torch.sin(ps),
                                torch.cos(pe), torch.sin(pe)], dim=-1)
 
         if self.mask_phases:
-            out[..., 3:] = 0.0
+            out[..., 7:] = 0.0
 
         return out
 
@@ -80,7 +90,7 @@ class ToneTokenEmbedding(nn.Module):
 
         Parameters
         ----------
-        raw_tokens : Tensor, shape (B, W, K, 5)
+        raw_tokens : Tensor, shape (B, W, K, 9)
 
         Returns
         -------


### PR DESCRIPTION
## Summary

- **Expanded token format from 5 to 9 fields**: `[snr, t_start, t_end, f_start, f_end, A_start, A_end, phase_start, phase_end]`. SNR is peak amplitude from the (optionally whitened) STFT. Time boundaries tile the signal. Boundary amplitudes are recovered via complementary weighted FFTs (`(1-t)*hann` and `t*hann`) with a precomputed mixing matrix inverse.
- **Corrected amplitude estimation**: Scalloping loss correction via precomputed Hann DTFT LUT, and parabolic frequency interpolation bias correction via separate LUT. Peaks are deduplicated along the dlnf axis.
- **Fixed phase computation**: Uses the actually-applied dechirp rate (not the refined estimate) for inverse warping, and quadratic phase interpolation in reconstruction to handle chirping signals.
- **New demos**: Token reconstruction, boundary continuity, merger signal reconstruction, and multi-resolution greedy token selection with frequency cutoff filtering.

## Test plan

- [ ] Run `python examples/token_reconstruction_demo.py` — verify SNR > 20 dB for noiseless chirp
- [ ] Run `python examples/token_continuity_demo.py` — verify boundary mismatches are small
- [ ] Run `python examples/merger_reconstruction_demo.py` — verify merger waveform reconstruction
- [ ] Run `python examples/multiresolution_demo.py` — verify multi-res SNR exceeds fine-only
- [ ] Run `python examples/transformer_demo.py` — verify embedding adapts to 9-field tokens

🤖 Generated with [Claude Code](https://claude.com/claude-code)